### PR TITLE
Add IB Overnight L1 support

### DIFF
--- a/elements/pages/trader-ib.js
+++ b/elements/pages/trader-ib.js
@@ -21,7 +21,7 @@ export const traderIbV3Template = html`
       ${documentPageHeaderPartial({
         pageUrl: import.meta.url
       })}
-      ${traderNameAndRuntimePartial()}
+      ${traderNameAndRuntimePartial({ editableCaps: true })}
       <section>
         <div class="label-group">
           <h5>Профиль брокера</h5>
@@ -97,6 +97,9 @@ export class TraderIbPage extends TraderCommonPage {
 
   getDefaultCaps() {
     return [
+      TRADER_CAPS.CAPS_LEVEL1,
+      TRADER_CAPS.CAPS_ORDERBOOK,
+      TRADER_CAPS.CAPS_BLUEATS,
       TRADER_CAPS.CAPS_LIMIT_ORDERS,
       TRADER_CAPS.CAPS_MARKET_ORDERS,
       TRADER_CAPS.CAPS_СONDITIONAL_ORDERS,

--- a/lib/aspirant-worker/ib-gateway/ib-gateway.mjs
+++ b/lib/aspirant-worker/ib-gateway/ib-gateway.mjs
@@ -1,5 +1,5 @@
 // ==PPPScript==
-// @version 11
+// @version 12
 // ==/PPPScript==
 
 import uWS from '/ppp/vendor/uWebSockets.js/uws.js';
@@ -190,6 +190,144 @@ class TwsConnection {
     }
   }
 
+  #mktDepthHandlersInstalled = false;
+
+  // tickerId → { status: 'pending' | 'active' | 'pending-cancel', timer }
+  #mktDepthState = new Map();
+
+  #installMktDepthHandlers() {
+    if (this.#mktDepthHandlersInstalled) return;
+    this.#mktDepthHandlersInstalled = true;
+
+    this.#api.api.on(
+      EventName.updateMktDepthL2,
+      (tickerId, position, marketMaker, operation, side, price, size, isSmartDepth) => {
+        const state = this.#mktDepthState.get(tickerId);
+
+        if (state) {
+          if (state.status === 'pending-cancel') {
+            clearTimeout(state.timer);
+            this.#mktDepthState.delete(tickerId);
+            this.#api.api.cancelMktDepth(tickerId, state.isSmartDepth);
+
+            return;
+          }
+
+          if (state.status === 'pending') {
+            clearTimeout(state.timer);
+            state.status = 'active';
+          }
+        }
+
+        this.#app.publish(
+          this.#key,
+          JSON.stringify({
+            message: 'marketDepth',
+            payload: { tickerId, position, marketMaker, operation, side, price, size, isSmartDepth }
+          })
+        );
+      }
+    );
+
+    this.#api.api.on(
+      EventName.updateMktDepth,
+      (tickerId, position, operation, side, price, size) => {
+        const state = this.#mktDepthState.get(tickerId);
+
+        if (state) {
+          if (state.status === 'pending-cancel') {
+            clearTimeout(state.timer);
+            this.#mktDepthState.delete(tickerId);
+            this.#api.api.cancelMktDepth(tickerId, state.isSmartDepth);
+
+            return;
+          }
+
+          if (state.status === 'pending') {
+            clearTimeout(state.timer);
+            state.status = 'active';
+          }
+        }
+
+        this.#app.publish(
+          this.#key,
+          JSON.stringify({
+            message: 'marketDepth',
+            payload: { tickerId, position, marketMaker: '', operation, side, price, size, isSmartDepth: false }
+          })
+        );
+      }
+    );
+  }
+
+  reqMktDepth(body = {}) {
+    const { tickerId, contract, numRows = 1, isSmartDepth = true } = body;
+
+    this.#installMktDepthHandlers();
+
+    this.#mktDepthState.set(tickerId, {
+      status: 'pending',
+      isSmartDepth,
+      timer: setTimeout(() => {
+        this.#mktDepthState.delete(tickerId);
+      }, 10000)
+    });
+
+    this.#api.api.reqMktDepth(
+      tickerId,
+      contract,
+      numRows,
+      isSmartDepth,
+      []
+    );
+
+    return { subscribed: true, tickerId };
+  }
+
+  cancelMktDepth(body = {}) {
+    const { tickerId, isSmartDepth = true } = body;
+
+    const state = this.#mktDepthState.get(tickerId);
+
+    if (state && state.status === 'pending') {
+      // TWS ещё не подтвердил подписку — отложить cancel.
+      state.status = 'pending-cancel';
+
+      return { cancelled: false, deferred: true, tickerId };
+    }
+
+    // active, pending-cancel, или не tracked — отправить cancel в TWS.
+    if (state) {
+      clearTimeout(state.timer);
+      this.#mktDepthState.delete(tickerId);
+    }
+
+    this.#api.api.cancelMktDepth(tickerId, isSmartDepth);
+
+    return { cancelled: true, tickerId };
+  }
+
+  cancelAllMktDepth() {
+    for (const [tickerId, state] of this.#mktDepthState) {
+      clearTimeout(state.timer);
+
+      if (state.status === 'active') {
+        this.#api.api.cancelMktDepth(tickerId, state.isSmartDepth);
+        this.#mktDepthState.delete(tickerId);
+      } else if (state.status === 'pending') {
+        state.status = 'pending-cancel';
+      } else {
+        this.#mktDepthState.delete(tickerId);
+      }
+    }
+  }
+
+  async reqContractDetails(body = {}) {
+    const { contract } = body;
+
+    return this.#api.getContractDetails(contract);
+  }
+
   async connect(body = {}) {
     if (!this.#api) {
       this.#api = new IBApiNext({
@@ -294,6 +432,8 @@ class IBGateway extends PPPUWSWorkerApplication {
   #connections = new Map();
 
   main() {
+    const connections = this.#connections;
+
     this.#app
       .ws('/*', {
         idleTimeout: 10,
@@ -301,14 +441,23 @@ class IBGateway extends PPPUWSWorkerApplication {
         maxBackpressure: 128 * 1024 * 1024,
         close: (ws) => {
           ws.closed = true;
+
+          if (ws.key) {
+            const connection = connections.get(ws.key);
+
+            if (connection) {
+              connection.cancelAllMktDepth();
+            }
+          }
         },
         message(ws, message) {
-          const key = Buffer.from(message).toString();
+          const text = Buffer.from(message).toString();
 
-          if (key) {
-            ws.key = key;
+          // First message is the subscription key (backwards compatible).
+          if (!ws.key) {
+            ws.key = text;
 
-            ws.subscribe(key);
+            ws.subscribe(text);
             ws.send(
               JSON.stringify({
                 message: 'subscription',
@@ -317,6 +466,34 @@ class IBGateway extends PPPUWSWorkerApplication {
                 }
               })
             );
+
+            return;
+          }
+
+          // Subsequent messages are JSON commands.
+          try {
+            const data = JSON.parse(text);
+            const connection = connections.get(ws.key);
+
+            if (
+              !connection ||
+              connection.connectionState !== ConnectionState.Connected
+            ) {
+              return;
+            }
+
+            switch (data.message) {
+              case 'reqMktDepth':
+                connection.reqMktDepth(data.payload);
+
+                break;
+              case 'cancelMktDepth':
+                connection.cancelMktDepth(data.payload);
+
+                break;
+            }
+          } catch (e) {
+            console.error('[ib-gateway] WS command error:', e);
           }
         }
       })
@@ -338,7 +515,8 @@ class IBGateway extends PPPUWSWorkerApplication {
             'getExecutionDetails',
             'getCurrentTime',
             'summary',
-            'positions'
+            'positions',
+            'reqContractDetails'
           ];
           const method = payload.method;
           const key = payload.key;

--- a/lib/traders/ib.js
+++ b/lib/traders/ib.js
@@ -8,11 +8,13 @@ import {
 import {
   ConditionalOrderDatum,
   GlobalTraderDatum,
+  TraderDatum,
   USTrader,
   pppTraderInstanceForWorkerIs
 } from './trader-worker.js';
 import { ConnectionError, TradingError } from '../ppp-exceptions.js';
 import { later } from '../ppp-decorators.js';
+import { isDST } from '../intl.js';
 
 export let ConnectionState;
 // biome-ignore lint/complexity/useArrowFunction: OK
@@ -480,6 +482,179 @@ class TimelineDatum extends IbTraderGlobalDatum {
   }
 }
 
+class MarketDepthDatum extends TraderDatum {
+  slotted = false;
+
+  // tickerId → symbol
+  #tickerIds = new Map();
+
+  // symbol → tickerId
+  #symbolToTickerId = new Map();
+
+  // symbol → { bids: Map<position, entry>, asks: Map<position, entry> }
+  #orderbooks = new Map();
+
+  // symbol → round lot size (persistent cache, survives unsub)
+  #roundLots = new Map();
+
+  // Symbols awaiting reqContractDetails HTTP response
+  #pendingContractDetails = new Set();
+
+  #nextTickerId = 0;
+
+  async subscribe(source, field, datum) {
+    await this.trader.establishWebSocketConnection();
+
+    return super.subscribe(source, field, datum);
+  }
+
+  firstReferenceAdded(source, symbol) {
+    const instrument = this.trader.instruments.get(symbol);
+
+    if (!instrument) return;
+
+    if (this.#symbolToTickerId.has(symbol)) return;
+
+    const tickerId = this.#nextTickerId++;
+
+    this.#tickerIds.set(tickerId, symbol);
+    this.#symbolToTickerId.set(symbol, tickerId);
+    this.#orderbooks.set(symbol, {
+      bids: new Map(),
+      asks: new Map()
+    });
+
+    const contract = {
+      symbol: this.trader.getSymbol(instrument),
+      exchange: 'SMART',
+      currency: instrument.currency ?? 'USD',
+      secType: SecType.STK
+    };
+
+    if (this.#roundLots.has(symbol)) {
+      this.trader.connection.send(
+        JSON.stringify({
+          message: 'reqMktDepth',
+          payload: { tickerId, contract, numRows: 20, isSmartDepth: true }
+        })
+      );
+    } else {
+      this.#pendingContractDetails.add(symbol);
+
+      fetch(`${this.trader.gatewayUrl}call`, {
+        method: 'POST',
+        body: JSON.stringify({
+          method: 'reqContractDetails',
+          key: this.trader.getGatewayKey(),
+          body: { contract }
+        })
+      })
+        .then((r) => r.json())
+        .then((details) => {
+          if (!this.#pendingContractDetails.has(symbol)) return;
+
+          this.#pendingContractDetails.delete(symbol);
+
+          const list = Array.isArray(details)
+            ? details
+            : (details?.result ?? []);
+
+          if (list.length > 0 && list[0].suggestedSizeIncrement > 0) {
+            this.#roundLots.set(symbol, list[0].suggestedSizeIncrement);
+          }
+
+          const tid = this.#symbolToTickerId.get(symbol);
+
+          if (typeof tid === 'undefined') return;
+
+          this.trader.connection.send(
+            JSON.stringify({
+              message: 'reqMktDepth',
+              payload: { tickerId: tid, contract, numRows: 20, isSmartDepth: true }
+            })
+          );
+        })
+        .catch((e) => console.error('[ib] reqContractDetails failed:', e));
+    }
+  }
+
+  lastReferenceRemoved(source, symbol) {
+    const tickerId = this.#symbolToTickerId.get(symbol);
+
+    if (typeof tickerId !== 'undefined') {
+      this.#tickerIds.delete(tickerId);
+      this.#symbolToTickerId.delete(symbol);
+      this.#orderbooks.delete(symbol);
+      this.#pendingContractDetails.delete(symbol);
+
+      if (this.trader.connection?.readyState === WebSocket.OPEN) {
+        this.trader.connection.send(
+          JSON.stringify({
+            message: 'cancelMktDepth',
+            payload: { tickerId, isSmartDepth: true }
+          })
+        );
+      }
+    }
+  }
+
+  handleMarketDepth(payload) {
+    // Blue Ocean ATS: EDT 8PM-4AM = UTC 0-8, EST 8PM-4AM = UTC 1-9.
+    const h = new Date().getUTCHours();
+    const isOvernight = isDST() ? h < 8 : h >= 1 && h < 9;
+
+    if (!isOvernight) return;
+
+    const { tickerId, position, marketMaker, operation, side, price, size } =
+      payload;
+
+    const symbol = this.#tickerIds.get(tickerId);
+
+    if (!symbol) return;
+
+    const instrument = this.trader.instruments.get(symbol);
+
+    if (!instrument) return;
+
+    let orderbook = this.#orderbooks.get(symbol);
+
+    if (!orderbook) {
+      orderbook = { bids: new Map(), asks: new Map() };
+      this.#orderbooks.set(symbol, orderbook);
+    }
+
+    const bookSide = side === 1 ? orderbook.bids : orderbook.asks;
+
+    if (operation === 2) {
+      bookSide.delete(position);
+    } else {
+      const roundLot = this.#roundLots.get(symbol) ?? 100;
+
+      bookSide.set(position, {
+        price,
+        volume: size * roundLot,
+        pool: marketMaker === 'OVERNIGHT' ? 'OVER' : marketMaker
+      });
+    }
+
+    const bids = [...orderbook.bids.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([, entry]) => entry);
+    const asks = [...orderbook.asks.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([, entry]) => entry);
+
+    this.dataArrived({ bids, asks }, instrument);
+  }
+
+  [TRADER_DATUM.ORDERBOOK](data) {
+    return {
+      bids: data.bids ?? [],
+      asks: data.asks ?? []
+    };
+  }
+}
+
 // noinspection JSUnusedGlobalSymbols
 /**
  * @typedef {Object} IbTrader
@@ -514,6 +689,10 @@ class IbTrader extends USTrader {
       {
         type: ConditionalOrderDatum,
         datums: [TRADER_DATUM.CONDITIONAL_ORDER]
+      },
+      {
+        type: MarketDepthDatum,
+        datums: [TRADER_DATUM.ORDERBOOK]
       }
     ]);
 
@@ -525,6 +704,10 @@ class IbTrader extends USTrader {
     urlObject.protocol = urlObject.protocol === 'http:' ? 'ws:' : 'wss:';
 
     this.wsUrl = urlObject.toString();
+  }
+
+  getGatewayKey() {
+    return this.#key;
   }
 
   async establishWebSocketConnection(reconnect) {
@@ -614,6 +797,8 @@ class IbTrader extends USTrader {
                 position
               });
             }
+          } else if (message === 'marketDepth') {
+            this.datums[TRADER_DATUM.ORDERBOOK]?.handleMarketDepth(payload);
           }
         };
       });


### PR DESCRIPTION
  ## Описание

  Поддержка стакана L1 для трейдера Interactive Brokers.

  ### Изменения

  **Gateway** (`ib-gateway.mjs`, @version 12):
  - `reqMktDepth` / `cancelMktDepth` через двунаправленные WebSocket-сообщения
  - State machine для отложенной отмены подписки (pending → active → pending-cancel) — защита от zombie-подписок при быстром переключении инструментов
  - `cancelAllMktDepth` при закрытии WebSocket очистка
  - `reqContractDetails` через HTTP для получения размера лота в штуках

  **Trader** (`ib.js`):
  - Новый класс `MarketDepthDatum` для датума ORDERBOOK
  - Запрос `suggestedSizeIncrement` из contract details для корректного пересчёта объёмов
  - Построение стакана из апдейтов (insert/update/delete)
  - Синхронные subscribe/unsubscribe через WebSocket для избежания race conditions при быстром переключении инструментов

  **UI** (`trader-ib.js`):
  - Редактируемые caps с дефолтами LEVEL1, ORDERBOOK, BLUEATS

  ### Примечания

  - Добавлены данные только для overnight-сессии — по одному уровню на сторону от пулов OVERNIGHT и IBEOS
  - Размеры лотов кешируются