### PR TITLE
Fix IB orderbook zero-size level removal

### DIFF
--- a/lib/traders/ib.js
+++ b/lib/traders/ib.js
@@ -630,7 +630,7 @@ class MarketDepthDatum extends TraderDatum {
 
     const bookSide = side === 1 ? orderbook.bids : orderbook.asks;
 
-    if (operation === 2) {
+    if (operation === 2 || size === 0) {
       bookSide.delete(position);
     } else {
       const roundLot = this.#roundLots.get(symbol) ?? 100;


### PR DESCRIPTION
  ## Описание

  Фикс удаления уровней с нулевым размером в стакане IB из-за которого слетала цветная разметка в интерфейсе виджета.

  ### Изменения

  **Trader** (`ib.js`):
  - `MarketDepthDatum`: добавлено условие `size === 0` для удаления уровня — IB иногда присылает operation 0 (insert) или 1 (update) с size=0 вместо
  operation 2 (delete)
